### PR TITLE
auto generate CRAN LICENSE file

### DIFF
--- a/R/rbuild.r
+++ b/R/rbuild.r
@@ -4,15 +4,38 @@
 #' Build a package located in \code{path} using \code{link[devtools]{build}}.
 #'
 #' @template path
+#' @param cran.license [\code{logical(1L)}]\cr
+#'   Replace the LICENSE File with a CRAN compatible version containing only: \cr
+#'   \code{YEAR: (current year)} \cr
+#'   \code{COPYRIGHT HOLDER: (first author found in the DESCRIPTION)}
 #' @template return-itrue
 #' @export
-rbuild = function(path = getwd()) {
+rbuild = function(path = getwd(), cran.license = FALSE) {
   pkg = devtools::as.package(path, create = FALSE)
   updatePackageAttributes(pkg)
 
   messagef("Building package '%s' ...", pkg$package)
   devtools::clean_vignettes(pkg)
+
+  if (cran.license) {
+    year = format(Sys.Date(), "%Y")
+    if (!is.null(pkg$`authors@r`)) {
+      copyright.holder = format(eval(parse(text = pkg$`authors@r`))[[1]], include = c("given", "family"))
+    } else {
+      copyright.holder = stri_match_first(pkg$author, regex = ".+?(?= <| \\[)")
+    }
+    tempfile = tempfile()
+    license.file = file.path(pkg$path, "LICENSE")
+    file.copy(license.file, tempfile)
+    writeLines(sprintf("YEAR: %s\nCOPYRIGHT HOLDER: %s", year, copyright.holder), con = license.file)
+  }
+
   loc = devtools::build(pkg)
+
+  if (cran.license) {
+    file.copy(tempfile, license.file)
+    file.remove(tempfile)
+  }
   messagef("The package has been bundled to '%s'.", normalizePath(loc))
   invisible(TRUE)
 }

--- a/inst/bin/rbuild
+++ b/inst/bin/rbuild
@@ -4,7 +4,11 @@ library("methods")
 library("rt")
 doc = "
 Usage:
-  rbuild [<path>]
+  rbuild [--cran.license] [<path>]
+Options:
+  --cran.license    Replace the LICENSE File with a CRAN compatible version containing only:
+                    YEAR: (current year)
+                    COPYRIGHT HOLDER: (first author found in the DESCRIPTION)
 "
 rt:::cli.call("rbuild", doc, commandArgs(TRUE))
 

--- a/man/rbuild.Rd
+++ b/man/rbuild.Rd
@@ -4,12 +4,17 @@
 \alias{rbuild}
 \title{Build a package}
 \usage{
-rbuild(path = getwd())
+rbuild(path = getwd(), cran.license = FALSE)
 }
 \arguments{
 \item{path}{[\code{character}]\cr
 If no path to a DESCRIPTION is given, the package looks for a DESCRIPTION in
 the current directory and up to two parent directories.}
+
+\item{cran.license}{[\code{logical(1L)}]\cr
+Replace the LICENSE File with a CRAN compatible version containing only: \cr
+\code{YEAR: (current year)} \cr
+\code{COPYRIGHT HOLDER: (first author found in the DESCRIPTION)}}
 }
 \value{
 Invisibly returns \code{TRUE} on success.


### PR DESCRIPTION
This is handy to allow github repositories to have a valid LICENSE File that can be parsed by github but to fulfill the CRAN policies that just want to have a two line LICENSE File stating the year and Copyright Holder.